### PR TITLE
Add CWA checkin support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,5 +29,8 @@ flask-migrate = "*"
 # https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/50 is resolved.
 sqlalchemy = "==1.3.*"
 
+unicode-slugify = "*"
+cwa-qr = "*"
+
 [requires]
 python_version = "3.9"

--- a/src/app.py
+++ b/src/app.py
@@ -1,12 +1,91 @@
 import os
 from datetime import datetime
 
-from flask import Flask, redirect, render_template, request
+from flask import Flask, redirect, render_template, request, url_for
+
+from typing import Optional, Union
 
 import sign_ins
 from config import ProductionConfig
 from db import db
 from migrate import migrate
+from slugify import slugify
+from hashlib import md5
+import cwa_qr
+from cwa_qr import CwaLocation
+
+class Location:
+    name: str
+    address: Optional[str]
+    type: CwaLocation
+    default_check_in_length: int
+    cwa_seed: Optional[str]
+
+    cwa_seed_prefix: str='corona-sign-in'
+
+    # Map names to CWA types
+    types = {
+        'generic': CwaLocation.permanent_other,
+        'retail': CwaLocation.permanent_retail,
+        'food': CwaLocation.permanent_food_service,
+        'craft': CwaLocation.permanent_craft,
+        'workplace': CwaLocation.permanent_workplace,
+        'educational': CwaLocation.permanent_educational_institution,
+        'public building': CwaLocation.permanent_public_building,
+    }
+
+    def __init__(self, name: str, address: Optional[str]=None,
+                 type: Union[str,CwaLocation]=CwaLocation.permanent_other,
+                 default_check_in_length: int=60, cwa_seed: Optional[str]=None,
+                 secret: Optional[str]=None):
+        if len(name) < 3:
+            raise ValueError('{name}: Invalid location name')
+        self.name = name
+
+        if address is not None and len(address) < 5:
+            raise ValueError(f'{name}: Invalid location address: {address}')
+        self.address = address
+
+        if isinstance(type, CwaLocation):
+            self.type = type
+        else:
+            if type not in self.types:
+                raise ValueError(f'{name}: Invalid location type: {type}')
+            self.type = self.types[type]
+
+        self.default_check_in_length = default_check_in_length
+        if cwa_seed is None and secret is not None:
+            digest = md5(f'{secret}-{name}'.encode()).hexdigest()
+            cwa_seed = f'{self.cwa_seed_prefix}-{digest}'
+        self.cwa_seed = cwa_seed
+
+    @classmethod
+    def create_with_id(cls, *args, **kwargs):
+        l = cls(*args, **kwargs)
+        return (l.id, l)
+
+    @property
+    def id(self):
+        return slugify(self.name)
+
+    def __str__(self):
+        return f'{self.name}, {self.address}'
+
+    def cwa_event(self):
+        event = cwa_qr.CwaEventDescription()
+        event.location_description = self.name
+        event.location_address = self.address
+        event.location_type = self.type
+        event.default_check_in_length_in_minutes = self.default_check_in_length
+        event.seed = self.cwa_seed
+        return event
+
+    def cwa_url(self):
+        try:
+            ev = self.cwa_event()
+            return cwa_qr.generate_url(ev)
+        except TypeError:
+            return None
 
 
 def create_app(config=None):
@@ -19,9 +98,19 @@ def create_app(config=None):
     db.init_app(app)
     migrate.init_app(app, db)
 
+    # Create the location list from either a simple list of names, or
+    # a dict of options for each location
+    locations_cfg = app.config["LOCATIONS"]
+    secret = app.config.get('SECRET_KEY')
+    if isinstance(locations_cfg, (tuple, list)):
+        locations = dict((Location.create_with_id(name, secret=secret)
+                          for name in locations_cfg))
+    else:
+        locations = dict((Location.create_with_id(name, secret=secret, **opts)
+                          for name, opts in locations_cfg.items()))
+
     @app.route("/", methods=("GET", "POST"))
     def index():
-        locations = app.config["LOCATIONS"]
         if locations:
             form = sign_ins.FormWithLocation(locations)
             preselected_location = request.args.get("location")
@@ -37,16 +126,20 @@ def create_app(config=None):
                 sign_ins.table.insert().values(**form.data, signed_in_at=datetime.now())
             )
             db.session.commit()
-            return redirect("/thank-you")
+            return redirect(url_for('.thank_you', location_id=form.location.data))
         return render_template("index.html.jinja2", form=form)
 
     @app.route("/data-protection")
     def data_protection():
         return render_template("data-protection.html.jinja2")
 
-    @app.route("/thank-you")
-    def thank_you():
-        return render_template("success-page.html.jinja2")
+    @app.route("/thank-you/<location_id>")
+    def thank_you(location_id):
+        location = locations.get(location_id)
+        if not location:
+            return render_template("error-page.html.jinja2", error="Invalid location"), 400
+
+        return render_template("success-page.html.jinja2", cwa_url=location.cwa_url())
 
     @app.errorhandler(500)
     def internal_server_error(e):

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,4 @@
-import sys
+import os
 from datetime import datetime
 
 from flask import Flask, redirect, render_template, request
@@ -13,6 +13,8 @@ def create_app(config=None):
     app = Flask(__name__)
 
     app.config.from_object(config if config else ProductionConfig())
+    if os.environ.get("CORONA_SIGN_IN_CONFIG"):
+        app.config.from_envvar("CORONA_SIGN_IN_CONFIG")
 
     db.init_app(app)
     migrate.init_app(app, db)

--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,7 @@ class ProductionConfig:
 
     @property
     def SQLALCHEMY_DATABASE_URI(self):
-        return os.environ["CORONA_SIGN_IN_DATABASE_URI"]
+        return os.environ.get("CORONA_SIGN_IN_DATABASE_URI")
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     """ This makes a deprecation warning go away. It doesn't change behaviour"""

--- a/src/sign_ins.py
+++ b/src/sign_ins.py
@@ -52,7 +52,12 @@ class FormWithLocation(Form):
     @property
     def data(self):
         data = super().data
-        data["location"] = b64decode(data["location"]).decode("utf-8")
+        try:
+            data["location"] = next(
+                label for (value, label) in self.location.choices if value == self.location.data
+            )
+        except StopIteration:
+            raise ValueError(f'Location id "{self.location.data}" not resolved')
         return data
 
     def set_location(self, location: str):

--- a/src/sign_ins.py
+++ b/src/sign_ins.py
@@ -45,8 +45,7 @@ class FormWithLocation(Form):
     def __init__(self, locations):
         super().__init__()
         self.location.choices = [("", "Bitte Auswählen")] + [
-            (b64encode(location.encode("utf-8")).decode("utf-8"), location)
-            for location in locations
+            (id, location.name) for id, location in locations.items()
         ]
 
     @property

--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -160,6 +160,7 @@ a:focus {
   font-size: 1rem;
   text-align: center;
   display: block;
+  margin: 0.5rem 0;
 }
 
 .footer-container {

--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -214,3 +214,8 @@ a:focus {
   height: auto;
   margin: 0.5rem;
 }
+
+.qr-code-container {
+  display: flex;
+  justify-content: center;
+}

--- a/src/templates/cwa-page.html.jinja2
+++ b/src/templates/cwa-page.html.jinja2
@@ -1,0 +1,14 @@
+{% extends "layout.html.jinja2" %}
+
+{% block title %}Corona-Warn-App{% endblock %}
+
+{% block headercontent %}
+  <h1 class="highlight">{{location}}</h1>
+{% endblock %}
+
+{% block content %}
+  <span class="description">Corona-Warn-App Check-in</span>
+  <div class="qr-code-container">
+    <img src="{{ qr_code }}"/>
+  </div>
+{% endblock %}

--- a/src/templates/success-page.html.jinja2
+++ b/src/templates/success-page.html.jinja2
@@ -6,6 +6,15 @@
   <h1 class="highlight">Danke</h1>
   <h2>Viel Spaß im Gängeviertel!</h2>
   <span class="description">Dein Eintrag wurde in unserer Datenbank gespeichert.</span>
+  {% if cwa_url %}
+    <div class="description">
+      Falls Sie die Corona-Warn-App verwenden können Sie sich über diesen
+      <div>
+        <a href="{{cwa_url}}">Link für die Veranstaltung einchecken.</a>
+      </div>
+      Sollte bei einem Teilnehmer dieser Veranstalltung SARS-CoV-2 nachgewiesen werden, erfolgt eine Warnung über die App schelller als es über die Kontakterfassung durch das Gesundheitsamt möglich ist.
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This series add support for the CWA check-in function as discussed in issue #151. It add a link to the "thank you" page that can open the CWA with the proper location data. It also add a page that can show the CWA QR code of each location.

For this to work we need at least the post address of each location, to support that the `LOCATION` config can now be a dictionary with each location name as key and a further config dictionary with the location config.